### PR TITLE
BUG: Fixes JSON file detection bug in `heatmap` visualizer 

### DIFF
--- a/q2_amr/card/heatmap.py
+++ b/q2_amr/card/heatmap.py
@@ -23,17 +23,25 @@ def heatmap(
     TEMPLATES = pkg_resources.resource_filename("q2_amr", "assets")
     annotation_dir = str(amr_annotation)
     with tempfile.TemporaryDirectory() as tmp:
+        # Create directories for the JSON annotation files and the heatmap output files
         results_dir = os.path.join(tmp, "results")
         json_files_dir = os.path.join(tmp, "json_files")
         os.makedirs(results_dir)
         os.makedirs(json_files_dir)
+
+        # Move all JSON files from the annotation directories into one json_files_dir.
+        # Files get renamed to include sample and bin name.
         for json_file in glob.glob(os.path.join(annotation_dir, "*", "*", "*.json")):
             sample, bin_name, _ = json_file.split(os.path.sep)[-3:]
-            destination_path = os.path.join(json_files_dir, f"{sample}_{bin_name}")
+            destination_path = os.path.join(json_files_dir, f"{sample}_{bin_name}.json")
             shutil.copy(json_file, destination_path)
 
+        # Run RGI heatmap function.
         run_rgi_heatmap(tmp, json_files_dir, clus, cat, display, frequency)
+
+        # Change names of all output files to not include number of files.
         change_names(results_dir)
+
         copy_tree(os.path.join(TEMPLATES, "rgi", "heatmap"), output_dir)
         copy_tree(results_dir, os.path.join(output_dir, "rgi_data"))
     context = {"tabs": [{"title": "Heatmap", "url": "index.html"}]}


### PR DESCRIPTION
This PR was created to fix #37. 

- The `heatmap` visualizer has to copy all JSON files from the annotation artifact to one directory and rename the files in the process.
- The files where missing the .json extension after the renaming and because of this were not detected.
- Now the .json is added to the destination path, what resolved the issue
- Added comments to the heatmap visualizer.

### Set up an environment
```bash
CONDA_SUBDIR=osx-64 mamba create -yn q2-amr \
  -c conda-forge -c bioconda -c qiime2 -c defaults \
  -c https://packages.qiime2.org/qiime2/2023.9/shotgun/released/ \
  qiime2 q2cli q2templates q2-types q2-types-genomics rgi

conda activate q2-amr
conda config --env --set subdir osx-64

pip install --no-deps --force-reinstall \
  git+https://github.com/misialq/rgi.git@py38-fix \
```

### Run it locally 
1. First, clone the repo and checkout the PR branch:
```bash
git clone https://github.com/bokulich-lab/q2-amr.git
cd q2-amr
git fetch origin pull/38/head:pr-38
git checkout pr-38
pip install -e .
```
2. [Download test file](https://polybox.ethz.ch/index.php/s/nJmbGpkM1ywS9VW) amr_annotations.qza

3. Test it out!
```bash
 qiime amr heatmap --i-amr-annotation amr_annotations.qza --o-visualization heatmap.qzv
```

Should look like this:

![Screenshot 2024-01-18 at 15 21 28](https://github.com/bokulich-lab/q2-amr/assets/100149044/28a70e27-e04c-46fc-a70f-c69fa02e7cb1)