### PR TITLE
MAINT: Changed all imports from types-genomics to types

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To install _q2-amr_, follow the steps described below.
 mamba create -yn q2-amr \
   -c conda-forge -c bioconda -c qiime2 -c defaults \
   -c https://packages.qiime2.org/qiime2/2023.9/shotgun/released/ \
-  qiime2 q2cli q2templates q2-types q2-types-genomics rgi
+  qiime2 q2cli q2templates q2-types rgi
 
 conda activate q2-amr
 
@@ -38,7 +38,7 @@ qiime info
 CONDA_SUBDIR=osx-64 mamba create -yn q2-amr \
   -c conda-forge -c bioconda -c qiime2 -c defaults \
   -c https://packages.qiime2.org/qiime2/2023.9/shotgun/released/ \
-  qiime2 q2cli q2templates q2-types q2-types-genomics rgi
+  qiime2 q2cli q2templates q2-types rgi
 
 conda activate q2-amr
 conda config --env --set subdir osx-64

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ To install _q2-amr_, follow the steps described below.
 
 ```shell
 mamba create -yn q2-amr \
-  -c conda-forge -c bioconda -c qiime2 -c defaults \
-  -c https://packages.qiime2.org/qiime2/2023.9/shotgun/released/ \
+  -c conda-forge -c bioconda -c defaults \
+  -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/ -c qiime2\
   qiime2 q2cli q2templates q2-types rgi
 
 conda activate q2-amr
@@ -36,8 +36,8 @@ qiime info
 
 ```shell
 CONDA_SUBDIR=osx-64 mamba create -yn q2-amr \
-  -c conda-forge -c bioconda -c qiime2 -c defaults \
-  -c https://packages.qiime2.org/qiime2/2023.9/shotgun/released/ \
+  -c conda-forge -c bioconda -c defaults \
+  -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/ -c qiime2\
   qiime2 q2cli q2templates q2-types rgi
 
 conda activate q2-amr

--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -19,7 +19,6 @@ requirements:
   run:
     - python {{ python }}
     - qiime2 {{ qiime2_epoch }}.*
-    - q2-types-genomics {{ qiime2_epoch }}.*
     - q2-types {{ qiime2_epoch }}.*
     - q2templates {{ qiime2_epoch }}.*
     - q2cli {{ qiime2_epoch }}.*

--- a/q2_amr/card/mags.py
+++ b/q2_amr/card/mags.py
@@ -4,7 +4,7 @@ import subprocess
 import tempfile
 
 import pandas as pd
-from q2_types_genomics.per_sample_data import MultiMAGSequencesDirFmt
+from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
 
 from q2_amr.card.utils import create_count_table, load_card_db, read_in_txt, run_command
 from q2_amr.types import CARDAnnotationDirectoryFormat, CARDDatabaseDirectoryFormat

--- a/q2_amr/card/tests/test_mags.py
+++ b/q2_amr/card/tests/test_mags.py
@@ -3,7 +3,7 @@ import shutil
 import subprocess
 from unittest.mock import MagicMock, patch
 
-from q2_types_genomics.per_sample_data import MultiMAGSequencesDirFmt
+from q2_types.per_sample_sequences import MultiMAGSequencesDirFmt
 from qiime2.plugin.testing import TestPluginBase
 
 from q2_amr.card.mags import annotate_mags_card, run_rgi_main

--- a/q2_amr/plugin_setup.py
+++ b/q2_amr/plugin_setup.py
@@ -9,11 +9,11 @@ import importlib
 
 from q2_types.feature_table import FeatureTable, Frequency
 from q2_types.per_sample_sequences import (
+    MAGs,
     PairedEndSequencesWithQuality,
     SequencesWithQuality,
 )
 from q2_types.sample_data import SampleData
-from q2_types_genomics.per_sample_data import MAGs
 from qiime2.core.type import Bool, Choices, Int, Properties, Range, Str, TypeMap
 from qiime2.plugin import Citations, Plugin
 

--- a/q2_amr/types/_format.py
+++ b/q2_amr/types/_format.py
@@ -12,7 +12,7 @@ from copy import copy
 import pandas as pd
 import qiime2.plugin.model as model
 from q2_types.feature_data._format import DNAFASTAFormat
-from q2_types_genomics.per_sample_data._format import BAMFormat, MultiDirValidationMixin
+from q2_types.per_sample_sequences._format import BAMFormat, MultiDirValidationMixin
 from qiime2.plugin import ValidationError
 
 

--- a/q2_amr/types/_transformer.py
+++ b/q2_amr/types/_transformer.py
@@ -14,7 +14,7 @@ import qiime2
 import skbio
 from q2_types.feature_data import DNAFASTAFormat, DNAIterator, ProteinFASTAFormat
 from q2_types.feature_data._transformer import ProteinIterator
-from q2_types_genomics.genome_data import GenesDirectoryFormat, ProteinsDirectoryFormat
+from q2_types.genome_data import GenesDirectoryFormat, ProteinsDirectoryFormat
 from skbio import DNA, Protein
 
 from q2_amr.types import CARDAnnotationDirectoryFormat

--- a/q2_amr/types/tests/test_types_formats_transformers.py
+++ b/q2_amr/types/tests/test_types_formats_transformers.py
@@ -20,7 +20,7 @@ from q2_types.feature_data import (
     ProteinFASTAFormat,
     ProteinIterator,
 )
-from q2_types_genomics.genome_data import GenesDirectoryFormat, ProteinsDirectoryFormat
+from q2_types.genome_data import GenesDirectoryFormat, ProteinsDirectoryFormat
 from qiime2.plugin.testing import TestPluginBase
 from skbio import DNA, Protein
 


### PR DESCRIPTION
Blocked by https://github.com/qiime2/q2-types/pull/309 
Solves #49 

- Changed all imports from q2-types-genomics to q2-types
- Updated Readme to include new qiime2 distribution 2024.2

### Set up an environment
```bash
CONDA_SUBDIR=osx-64 mamba create -yn q2-amr \
  -c conda-forge -c bioconda -c defaults \
  -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/ -c qiime2 \
  qiime2 q2cli q2templates q2-types rgi

conda activate q2-amr
conda config --env --set subdir osx-64

pip install --no-deps --force-reinstall \
  git+https://github.com/misialq/rgi.git@py38-fix \
```

### Run it locally 
1. First, clone the repo and checkout the PR branch:
```bash
git clone https://github.com/bokulich-lab/q2-amr.git
cd q2-amr
git fetch origin pull/50/head:pr-50
git checkout pr-50
pip install -e .
```
2. Download test files 
[Download test files](https://polybox.ethz.ch/index.php/s/nJmbGpkM1ywS9VW): mags.qza, card_db.qza 


3. Test it out!
```bash
qiime amr annotate-mags-card --i-mag mags.qza --i-card-db /Users/rischv/Documents/data/card_database/wildcard/card_db.qza --output-dir amr_pr-50
 ```