### PR TITLE
MAINT: Added progress bar and informative prints to `fetch-card-db` action.

### DIFF
--- a/q2_amr/card/database.py
+++ b/q2_amr/card/database.py
@@ -7,6 +7,7 @@ import tarfile
 import tempfile
 
 import requests
+from tqdm import tqdm
 
 from q2_amr.card.utils import run_command
 from q2_amr.types._format import (
@@ -24,8 +25,42 @@ def fetch_card_db() -> (CARDDatabaseDirectoryFormat, CARDKmerDatabaseDirectoryFo
         response_wildcard = requests.get(
             "https://card.mcmaster.ca/latest/variants", stream=True
         )
+
+        # Get content length to calculate progress
+        total_size_card = int(response_card.headers.get("content-length", 0))
+        total_size_wildcard = int(response_wildcard.headers.get("content-length", 0))
+
+        # Initialize progress bars
+        progress_bar_card = tqdm(
+            total=total_size_card,
+            unit="B",
+            unit_scale=True,
+            desc="Downloading CARD database",
+        )
+
+        progress_bar_wildcard = tqdm(
+            total=total_size_wildcard,
+            unit="B",
+            unit_scale=True,
+            desc="Downloading WildCARD database",
+        )
+
+        # Update progress bars
+
+        for data_card in response_card.iter_content(chunk_size=4096):
+            progress_bar_card.update(len(data_card))
+        progress_bar_card.close()
+
+        for data_wildcard in response_wildcard.iter_content(chunk_size=4096):
+            progress_bar_wildcard.update(len(data_wildcard))
+        progress_bar_wildcard.close()
+
     except requests.ConnectionError as e:
-        raise requests.ConnectionError("Network connectivity problems.") from e
+        error_msg = "Unable to connect to the CARD server. Please try again later."
+        raise requests.ConnectionError(error_msg) from e
+
+    msg = "Download finished. Extracting database files..."
+    print(f"{msg}", end="", flush=True)
 
     # Create temporary directory for WildCARD data
     with tempfile.TemporaryDirectory() as tmp_dir:
@@ -63,10 +98,20 @@ def fetch_card_db() -> (CARDDatabaseDirectoryFormat, CARDKmerDatabaseDirectoryFo
             ) as f_out:
                 f_out.write(f_in.read())
 
+        print(f"\r{msg} Done.", flush=True)
+
+        msg = "Preprocessing database files..."
+        print(f"{msg}", end="", flush=True)
+
         # Preprocess data for CARD and WildCARD
         # This creates additional fasta files in the temp directory
         preprocess(dir=tmp_dir, operation="card")
         preprocess(dir=tmp_dir, operation="wildcard")
+
+        print(f"\r{msg} Done.", flush=True)
+
+        msg = "Creating database artifacts..."
+        print(f"{msg}", end="", flush=True)
 
         # Create CARD and Kmer database objects
         card_db = CARDDatabaseDirectoryFormat()

--- a/q2_amr/card/tests/test_database.py
+++ b/q2_amr/card/tests/test_database.py
@@ -39,6 +39,12 @@ class TestAnnotateMagsCard(TestPluginBase):
         mock_response_card = MagicMock(raw=f_card)
         mock_response_wildcard = MagicMock(raw=f_wildcard)
 
+        # Add values to mocked responses for progressbar
+        mock_response_card.headers = {"content-length": 1024}
+        mock_response_card.iter_content.return_value = [b"test"] * 1024
+        mock_response_wildcard.headers = {"content-length": 1024}
+        mock_response_wildcard.iter_content.return_value = [b"test"] * 1024
+
         # Patch requests.get,
         with patch("requests.get") as mock_requests, patch(
             "q2_amr.card.database.preprocess", side_effect=self.mock_preprocess
@@ -85,7 +91,8 @@ class TestAnnotateMagsCard(TestPluginBase):
         with patch(
             "requests.get", side_effect=requests.ConnectionError
         ), self.assertRaisesRegex(
-            requests.ConnectionError, "Network connectivity problems."
+            requests.ConnectionError,
+            "Unable to connect to the CARD server. Please try again later.",
         ):
             fetch_card_db()
 


### PR DESCRIPTION
This PR closes #67 

- Added progress bar and informative prints to `fetch-card-db` action.

### Set up an environment for intel
```bash
mamba create -yn q2-amr \
  -c conda-forge -c bioconda -c qiime2 -c defaults \
  -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/ \
  qiime2 q2cli q2templates q2-types rgi

conda activate q2-amr

pip install --no-deps --force-reinstall \
  git+https://github.com/misialq/rgi.git@py38-fix \
```

### Run it locally 
1. First, clone the repo and checkout the PR branch:
```bash
git clone https://github.com/bokulich-lab/q2-amr.git
cd q2-amr
git fetch origin pull/68/head:pr-68
git checkout pr-68
pip install -e .
```

3. Test it out!
```bash
qiime amr fetch-card-db --output-dir card_database --verbose
 ```
 
 4. Check if partitioned artifacts from allele annotations and gene annotations are of type `SampleData[CARDGeneAnnotation % Properties('kma')]`