### PR TITLE
BUG: Changed installation instructions in README to install unreleased qiime2 version 2024.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ conda activate q2-amr
 pip install --no-deps --force-reinstall \
   git+https://github.com/misialq/rgi.git@py38-fix \
   git+https://github.com/bokulich-lab/q2-amr.git
+
+pip install git+https://github.com/qiime2/qiime2.git
 ```
 
 Refresh cache and check that everything worked:
@@ -46,6 +48,8 @@ conda config --env --set subdir osx-64
 pip install --no-deps --force-reinstall \
   git+https://github.com/misialq/rgi.git@py38-fix \
   git+https://github.com/bokulich-lab/q2-amr.git
+
+pip install git+https://github.com/qiime2/qiime2.git
 ```
 
 Refresh cache and check that everything worked:


### PR DESCRIPTION
temporary fix for #69 

### Set up an environment for apple silicone
```bash
CONDA_SUBDIR=osx-64 mamba create -yn q2-amr \
  -c conda-forge -c bioconda -c qiime2 -c defaults \
  -c https://packages.qiime2.org/qiime2/2024.2/shotgun/released/ \
  qiime2 q2cli q2templates q2-types rgi

conda activate q2-amr
conda config --env --set subdir osx-64

pip install --no-deps --force-reinstall \
  git+https://github.com/misialq/rgi.git@py38-fix \

pip install git+https://github.com/qiime2/qiime2.git  
```

### Run it locally 
1. First, clone the repo and checkout the PR branch:
```bash
git clone https://github.com/bokulich-lab/q2-amr.git
cd q2-amr
git fetch origin pull/70/head:pr-70
git checkout pr-70
pip install -e .
```
2. Download test files 
[PR_56.zip](https://github.com/bokulich-lab/q2-amr/files/14865943/PR_56.zip)



3. Test it out!
Run all these commands from the PR_56 directory Last two should fail.
```bash
qiime amr collate-reads-allele-annotations --i-annotations partition_reads_allele/sample1.qza partition_reads_allele/sample2.qza --o-collated-annotations partition_reads_allele/collate.qza

 ```