### PR TITLE
BUG: added database_format_version.txt to AMRFinderPlusAnnotationsDirFmt

### DIFF
--- a/q2_amr/amrfinderplus/types/_format.py
+++ b/q2_amr/amrfinderplus/types/_format.py
@@ -33,6 +33,7 @@ class AMRFinderPlusDatabaseDirFmt(model.DirectoryFormat):
     fam = model.File("fam.tab", format=TextFormat)
     taxgroup = model.File("taxgroup.tab", format=TextFormat)
     version = model.File("version.txt", format=TextFormat)
+    db_fmt_version = model.File("database_format_version.txt", format=TextFormat)
     amr_dna = model.FileCollection(
         r"^AMR_DNA-[a-zA-Z_]+$", format=MixedCaseDNAFASTAFormat
     )


### PR DESCRIPTION
solves #91 


### Set up an environment 
https://github.com/bokulich-lab/q2-amr?tab=readme-ov-file#installation

### Run it locally 
1. First, clone the repo and checkout the PR branch:
```bash
git clone https://github.com/bokulich-lab/q2-amr.git
cd q2-amr
git fetch origin pull/92/head:pr-92
git checkout pr-92
pip install -e .
```
2. Download test files 
amrfinderplus_database.zip: https://polybox.ethz.ch/index.php/s/nJmbGpkM1ywS9VW


3. Test it out!
```bash
qiime tools import --input-path database --output-path database.qza --type AMRFinderPlusDatabase 
```
