### PR TITLE
LANG: recipe updates for pathogenome distro

### DIFF
--- a/ci/recipe/meta.yaml
+++ b/ci/recipe/meta.yaml
@@ -1,24 +1,23 @@
-{% set data = load_setup_py_data() %}
-{% set version = data.get('version') or 'placehold' %}
-
 package:
   name: q2-amr
-  version: {{ version }}
+  version: {{ PLUGIN_VERSION }}
 
 source:
   path: ../..
 
 build:
+  script-env:
+    - PLUGIN_VERSION
   script: make install
 
 requirements:
   host:
-    - python=3.8.*
+    - python {{ python }}
     - setuptools
 
   run:
     - ncbi-amrfinderplus
-    - python=3.8.*
+    - python {{ python }}
     - qiime2 {{ qiime2_epoch }}.*
     - q2-demux {{ qiime2_epoch }}.*
     - q2-feature-table {{ qiime2_epoch }}.*


### PR DESCRIPTION
Hey @VinzentRisch @misialq,

I'm currently working on getting a working metapackage build for the pathogenome distro (name attribution to @cherman2). In order for q2-amr to be compatible, the python version needs to match the seed environment spec (which is currently 3.9, and will soon be 3.10 in the upcoming release). This may break current functionality upon merge, but we can just leave this as an open PR until I get the rest of the distribution working.

distributions PR: https://github.com/qiime2/distributions/pull/366