### PR TITLE
CI: pin mamba version to prevent failures in setup_miniconda

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: conda-incubator/setup-miniconda@v3
         with:
           python-version: 3.8
-          mamba-version: "*"
+          mamba-version: 1.5.10
           channels: conda-forge,defaults
           channel-priority: true
           activate-environment: conda-env


### PR DESCRIPTION
solves #109
- pins mamba version to 1.5.10 in ci.yaml