### PR TITLE
MAINT: add env file for QIIME 2 2026.1

### DIFF
--- a/environment-files/q2-rgi-qiime2-amplicon-2026.1.yml
+++ b/environment-files/q2-rgi-qiime2-amplicon-2026.1.yml
@@ -1,0 +1,16 @@
+channels:
+- https://packages.qiime2.org/qiime2/2026.1/amplicon/released
+- conda-forge
+- bioconda
+dependencies:
+  - qiime2
+  - q2-demux
+  - q2-feature-table
+  - q2-types
+  - q2templates
+  - q2cli
+  - rgi
+  - tqdm
+  - pip
+  - pip:
+     - "q2-rgi@git+https://github.com/bokulich-lab/q2-rgi.git@2026.1"


### PR DESCRIPTION
This PR adds a new environment file for QIIME 2 2026.1.

Generated from the latest env file in 'environment-files/' by updating the release token.