### PR TITLE
BUG: change link to 2026.1 tag in env file

### DIFF
--- a/environment-files/q2-rgi-qiime2-amplicon-2026.1.yml
+++ b/environment-files/q2-rgi-qiime2-amplicon-2026.1.yml
@@ -13,4 +13,4 @@ dependencies:
   - tqdm
   - pip
   - pip:
-     - "q2-rgi@git+https://github.com/bokulich-lab/q2-rgi.git@2026.1"
+     - "q2-rgi@git+https://github.com/bokulich-lab/q2-rgi.git@2026.1.0"


### PR DESCRIPTION
closes #159 

The link in the env file for the 2026.1 release had a typo and was not pointing to the correct release. 